### PR TITLE
Possible fix for error in detecting m2.5 DRC rule

### DIFF
--- a/drc/drc_sky130.lydrc
+++ b/drc/drc_sky130.lydrc
@@ -503,8 +503,8 @@ via.not(m2).output("m2.via", "m2.via : m2 must enclose via")
 if backend_flow = AL
   m2.enclosing(via, 0.055, euclidian).output("m2.4", "m2.4 : min. m2 enclosure of via : 0.055um")
   via_edges_with_less_enclosure_m2 = m2.enclosing(via, 0.085, projection).second_edges
-  opposite7 = (via.edges - via_edges_with_less_enclosure_m2).width(0.14 + 1.dbu, projection).polygons
-  via.not_interacting(opposite7).output("m2.5", "m2.5 : min. m2 enclosure of via of 2 opposite edges : 0.085um")
+  opposite7 = via_edges_with_less_enclosure_m2.width(0.15 + 1.dbu, projection).polygons
+  via.interacting(opposite7).output("m2.5", "m2.5 : min. m2 enclosure of via of 2 opposite edges : 0.085um")
   # rule m2.pd.1, rule m2.pd.2a, rule m2.pd.2b not coded
 end
 if bakend_flow = CU


### PR DESCRIPTION
Hi @laurentc2 ,

First of all, thanks a ton for your cool script!!

I happen to notice that there is a bug in detecting m2.5 DRC error. In first scenario, the error won't go even after providing proper enclosures to the via as argument to .width() is 0.14. Since minimum width of via is 0.15um, polygons would never be created and always .not_interacting would highlight the via as a DRC violation.

Even after changing this argument from 0.14 to 0.15, I noticed that there were some cases where the code wouldn't highlight the via during an actual DRC violation. Please have a look at the attached excel file for more details on this. Hence I suggest a small fix for this issue. 

Looking forward to hear your thoughts on same :) 

Thanking you,
Vishal

Before correcting 0.14um
![before correcting 0 14](https://github.com/laurentc2/SKY130_for_KLayout/assets/56384150/2fb6e3bf-992f-4479-873f-ab22a5100dfe)

After correcting 0.14um
![after correcting 0 14](https://github.com/laurentc2/SKY130_for_KLayout/assets/56384150/7d8bf9b8-f7d6-47b3-b7bf-566d1031b701)


[DRC script fix explanation.xlsx](https://github.com/laurentc2/SKY130_for_KLayout/files/12092285/DRC.script.fix.explanation.xlsx)

